### PR TITLE
fb.user_id needs to be parsed to int to compare with author_id.

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -82,7 +82,7 @@ def main():
             log.debug('%s(%s): %s', author_name, author_id, message)
 
             # if author is myself, leave him alone
-            if author_id == fb.user_id:
+            if author_id == int(fb.user_id):
                 continue
 
             if tid.startswith('mid'):


### PR DESCRIPTION
fb.user_id needs to be parsed to int to compare with author_id, or we cant leave bot alone
:santa: 
